### PR TITLE
fix: loadgen node detached error

### DIFF
--- a/src/loadgen/src/helpers/common.ts
+++ b/src/loadgen/src/helpers/common.ts
@@ -54,6 +54,7 @@ export async function gotoPageWithNavBar(
 ): Promise<void> {
     await showNavbar(pageActions)
     await pageActions.navigate(navBarSelector)
+    await pageActions.standardDelay()
 }
 
 export async function pageSetup(page: Page, user: User, appUrl: URL) {


### PR DESCRIPTION
fix: add a delay after navigating to a page with navbar to allow for all nodes to render properly