### PR TITLE
fix: explicitly disable credit_card_meltdown flag in all deployment configs

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -220,6 +220,7 @@ services:
       - 8094:8080
     environment:
       PROXY_PREFIX: feature-flag-service
+      ENABLE_CREDIT_CARD_MELTDOWN: "false"
       # ENABLE_MODIFY: "false"
       # ENABLE_FRONTEND_MODIFY: "false"
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -150,6 +150,7 @@ services:
     image: ${REGISTRY}/feature-flag-service:${TAG}
     environment:
       PROXY_PREFIX: feature-flag-service
+      ENABLE_CREDIT_CARD_MELTDOWN: "false"
 
   accountservice:
     <<: *default-service

--- a/helm/easytrade/values.yaml
+++ b/helm/easytrade/values.yaml
@@ -170,6 +170,7 @@ feature-flag-service:
     FEATURE_FLAG_SERVICE_PROTOCOL: http
     FEATURE_FLAG_SERVICE_BASE_URL: "{{ .Release.Name }}-feature-flag-service"
     FEATURE_FLAG_SERVICE_PORT: "8080"
+    ENABLE_CREDIT_CARD_MELTDOWN: "false"
   resources:
     requests:
       cpu: 30m


### PR DESCRIPTION
## Summary

- **Root cause (P-260614079):** The `ENABLE_CREDIT_CARD_MELTDOWN` env var was set to `true` in the `eks-live` deployment spec for `feature-flag-service`, enabling the `credit_card_meltdown` OpenFeature flag. This caused `OrderController.getLatestStatus` to call `CountArythmeticSequenceTotal`, which divides by zero on every invocation — resulting in a 100% failure rate on the endpoint and impacting 82 users over ~24 hours.
- **Fix:** Explicitly set `ENABLE_CREDIT_CARD_MELTDOWN: "false"` in `helm/easytrade/values.yaml`, `compose.yaml`, and `compose.dev.yaml`. The `application.properties` default was already `false`, but an explicit env var in the deployment config overrode it. Pinning it here ensures a deployment spec change cannot silently re-enable the meltdown.

## Test plan

- [ ] Deploy to staging with this change and confirm `GET /v1/orders/{accountId}/status/latest` returns 200 for valid accounts
- [ ] Verify the `credit_card_meltdown` flag shows `false` in the feature-flag-service UI
- [ ] Confirm no division-by-zero errors appear in OrderController logs

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)