### PR TITLE
chore: upgrade GitHub Actions to Node 24 (Node 20 deprecation)

### DIFF
--- a/.github/workflows/reusable-promote-release.yaml
+++ b/.github/workflows/reusable-promote-release.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Create release
         id: create-release
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const version = 'v${{ inputs.version }}';
@@ -72,7 +72,7 @@ jobs:
 
       - name: Upload release assets
         if: ${{ inputs.artifact-dir }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           ARTIFACT_DIR: ${{ inputs.artifact-dir }}
         with:
@@ -117,7 +117,7 @@ jobs:
             }
 
       - name: Trigger deploy workflow
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         if: ${{ inputs.trigger-deploy }}
         with:
           script: |

--- a/.github/workflows/reusable-snyk.yaml
+++ b/.github/workflows/reusable-snyk.yaml
@@ -18,7 +18,7 @@ jobs:
       SNYK_TOKEN: ${{ secrets.SNYK_API_TOKEN }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Snyk CLI
         uses: snyk/actions/setup@master
@@ -29,18 +29,18 @@ jobs:
           dotnet-version: 8.0
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: temurin
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: "src/pricing-service/go.mod"
 


### PR DESCRIPTION
## Summary

Upgrades outdated GitHub Actions to Node 24 compatible versions, fixing Node 20 deprecation warnings on GitHub-hosted runners.

**Related:** ASDY-27739

## Test plan

- [ ] CI passes on this PR
- [ ] No Node 20 deprecation warnings in workflow runs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)