### PR TITLE
fix: resolve division-by-zero in CountArythmeticSequenceTotal

### DIFF
--- a/src/credit-card-order-service/src/main/java/com/dynatrace/easytrade/creditcardorderservice/OrderController.java
+++ b/src/credit-card-order-service/src/main/java/com/dynatrace/easytrade/creditcardorderservice/OrderController.java
@@ -322,11 +322,9 @@ public class OrderController {
 
     private int CountArythmeticSequenceTotal(int firstElement, int step, int count)
     {
-        // this has a wrong value (normally would be 2), because we want to create an exception!
-        int theGreatDivider = 0;
+        int theGreatDivider = 2;
 
         int lastElement = firstElement + (step * (count - 1));
-        // deepcode ignore DivisionByZero: exception should be thrown here
         int total = (firstElement + lastElement) * count / theGreatDivider;
 
         return total;


### PR DESCRIPTION
The credit_card_meltdown feature flag triggered a call to CountArythmeticSequenceTotal with theGreatDivider hardcoded to 0, causing ArithmeticException on every getLatestStatus request (P-26074631). Restores the correct arithmetic sequence sum formula (divisor = 2).