### PR TITLE
fix: disable ENABLE_CREDIT_CARD_MELTDOWN in feature-flag-service manifests (P-26079133)

### DIFF
--- a/kubernetes-manifests/base/feature-flag-service.yaml
+++ b/kubernetes-manifests/base/feature-flag-service.yaml
@@ -16,7 +16,9 @@ spec:
           image: feature-flag-service
           ports:
             - containerPort: 8080
-          env: []
+          env:
+            - name: ENABLE_CREDIT_CARD_MELTDOWN
+              value: "false"
           resources:
             requests:
               cpu: 30m

--- a/kubernetes-manifests/release/feature-flag-service.yaml
+++ b/kubernetes-manifests/release/feature-flag-service.yaml
@@ -16,7 +16,9 @@ spec:
           image: europe-docker.pkg.dev/dynatrace-demoability/docker/easytrade/feature-flag-service:98288cf
           ports:
             - containerPort: 8080
-          env: []
+          env:
+            - name: ENABLE_CREDIT_CARD_MELTDOWN
+              value: "false"
           resources:
             requests:
               cpu: 30m


### PR DESCRIPTION
## Summary

- Explicitly sets `ENABLE_CREDIT_CARD_MELTDOWN=false` in both `base` and `release` feature-flag-service Kubernetes manifests
- Fixes active problem **P-26079133**: the flag was enabled on the live cluster causing 100% failure rate on `credit-card-order-service` OrderController and ~8.6% error rate on the frontend (affecting ~66 users)
- Previously the manifests used `env: []`, relying on the Spring Boot default — a direct cluster patch to set `ENABLE_CREDIT_CARD_MELTDOWN=true` overrode that default and was not caught by the manifests

## Root cause

The `credit_card_meltdown` feature flag triggers an intentional division-by-zero in `OrderController.CountArythmeticSequenceTotal`, making every `/status/latest` call throw. Someone set `ENABLE_CREDIT_CARD_MELTDOWN=true` directly on the running deployment. Redeploying from the existing manifest (with `env: []`) would have restored the default, but an explicit `false` prevents the same incident from recurring via cluster patch.

## Test plan

- [ ] Redeploy `feature-flag-service` from the updated manifest
- [ ] Confirm `credit-card-order-service` OrderController failure rate returns to baseline (< 25%)
- [ ] Confirm `frontendreverseproxy` error rate drops back to ~0%
- [ ] Verify problem P-26079133 closes in Dynatrace

🤖 Generated with [Claude Code](https://claude.com/claude-code)