### PR TITLE
fix(user-service): restore build broken by proto migration

### DIFF
--- a/src/user-service/account/handler.go
+++ b/src/user-service/account/handler.go
@@ -1,14 +1,12 @@
 package account
 
 import (
-	"context"
 	"net/http"
 	"strconv"
 
 	"dynatrace.com/easytrade/user-service/proto"
 	"dynatrace.com/easytrade/user-service/utils"
 	"github.com/gin-gonic/gin"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"

--- a/src/user-service/account/mock_client_test.go
+++ b/src/user-service/account/mock_client_test.go
@@ -11,6 +11,9 @@ import (
 )
 
 type fakeAccountServiceClient struct {
+	// Embedded so the fake satisfies the full generated interface. It is nil:
+	// only the methods defined below are callable, the rest panic if reached.
+	proto.AccountServiceClient
 	accounts map[string]*proto.AccountMessage
 }
 
@@ -67,6 +70,8 @@ func (f *fakeAccountServiceClient) GetAccounts(_ context.Context, _ *emptypb.Emp
 }
 
 type fakeBalanceServiceClient struct {
+	// As above; the Handler only calls CreateBalance.
+	proto.BalanceServiceClient
 	balances map[string]*proto.BalanceMessage
 }
 


### PR DESCRIPTION
## fix(user-service): restore build broken by proto migration

### Problem
`user-service` fails to build on a clean cache. The Dockerfile gates the binary on
`go test ./...`

```
account/handler.go:4:2:  "context" imported and not used
account/handler.go:11:2: "google.golang.org/grpc" imported and not used
vet: *fakeAccountServiceClient does not implement proto.AccountServiceClient
     (missing method DeleteAccountsOlderThan)
```

### Root cause
#204 replaced the checked-in `dbadapter/proto` stubs with code generated at build time
`BalanceServiceClient` (5 methods) for balance creation on signup. The test fakes were
left implementing 5 of the 10 required methods, and two imports were added to
`handler.go` that nothing uses.

### Fix
- Drop the unused `context` / `grpc` imports from `handler.go`.
- Embed the generated interfaces in the test fakes, so they satisfy the full client
  contract without hand-written stubs for RPCs the handler never calls. New RPCs added
  to the `.proto` files will no longer break these tests.