### PR TITLE
refactor: GetOrdersToManufacture method

### DIFF
--- a/src/db-adapter/repository/sql/creditcard.go
+++ b/src/db-adapter/repository/sql/creditcard.go
@@ -105,11 +105,15 @@ func (repo *CreditCardOrderRepository) GetLastStatusByOrderID(ctx context.Contex
 }
 
 func (repo *CreditCardOrderRepository) GetOrdersToManufacture(ctx context.Context) ([]*pb.CreditCardManufactureDataMessage, error) {
-	statusTableName := q(repository.TableCreditCardOrderStatus)
-	condition := `(SELECT TOP 1 ` + q(repository.ColStatus) + ` FROM ` + statusTableName +
-		` WHERE ` + q(repository.ColCreditCardOrderID) + ` = ` + qcol(repository.TableCreditCardOrders, repository.ColID) +
-		` ORDER BY ` + q(repository.ColTimestamp) + ` DESC) = ?`
-	query := repo.db.WithContext(ctx).Where(condition, repository.StatusOrderCreated)
+	// Use GORM's subquery builder which handles dialect differences (TOP 1 vs LIMIT 1)
+	latestStatusSubquery := repo.db.
+		Table(repository.TableCreditCardOrderStatus).
+		Select(q(repository.ColStatus)).
+		Where(q(repository.ColCreditCardOrderID) + " = " + qcol(repository.TableCreditCardOrders, repository.ColID)).
+		Order(q(repository.ColTimestamp) + " DESC").
+		Limit(1)
+
+	query := repo.db.WithContext(ctx).Where("(?) = ?", latestStatusSubquery, repository.StatusOrderCreated)
 	return findAndMapAll(query, (*CreditCardOrder).toManufactureDataProto)
 }
 

--- a/src/db-adapter/repository/sql/creditcard.go
+++ b/src/db-adapter/repository/sql/creditcard.go
@@ -105,11 +105,12 @@ func (repo *CreditCardOrderRepository) GetLastStatusByOrderID(ctx context.Contex
 }
 
 func (repo *CreditCardOrderRepository) GetOrdersToManufacture(ctx context.Context) ([]*pb.CreditCardManufactureDataMessage, error) {
-	join := "JOIN " + q(repository.TableCreditCardOrderStatus) +
-		" ON " + qcol(repository.TableCreditCardOrderStatus, repository.ColCreditCardOrderID) +
-		" = " + qcol(repository.TableCreditCardOrders, repository.ColID)
-	where := qcol(repository.TableCreditCardOrderStatus, repository.ColStatus) + " = ?"
-	query := repo.db.WithContext(ctx).Joins(join).Where(where, repository.StatusOrderCreated)
+	statusTableName := q(repository.TableCreditCardOrderStatus)
+	statusOrderIDColumn := q(repository.ColCreditCardOrderID)
+	ordersTableIDColumn := qcol(repository.TableCreditCardOrders, repository.ColID)
+	statusCountCondition := `(SELECT COUNT(*) FROM ` + statusTableName + ` WHERE ` + statusOrderIDColumn + ` = ` + ordersTableIDColumn + `) = 1`
+
+	query := repo.db.WithContext(ctx).Where(statusCountCondition)
 	return findAndMapAll(query, (*CreditCardOrder).toManufactureDataProto)
 }
 

--- a/src/db-adapter/repository/sql/creditcard.go
+++ b/src/db-adapter/repository/sql/creditcard.go
@@ -106,11 +106,10 @@ func (repo *CreditCardOrderRepository) GetLastStatusByOrderID(ctx context.Contex
 
 func (repo *CreditCardOrderRepository) GetOrdersToManufacture(ctx context.Context) ([]*pb.CreditCardManufactureDataMessage, error) {
 	statusTableName := q(repository.TableCreditCardOrderStatus)
-	statusOrderIDColumn := q(repository.ColCreditCardOrderID)
-	ordersTableIDColumn := qcol(repository.TableCreditCardOrders, repository.ColID)
-	statusCountCondition := `(SELECT COUNT(*) FROM ` + statusTableName + ` WHERE ` + statusOrderIDColumn + ` = ` + ordersTableIDColumn + `) = 1`
-
-	query := repo.db.WithContext(ctx).Where(statusCountCondition)
+	condition := `(SELECT TOP 1 ` + q(repository.ColStatus) + ` FROM ` + statusTableName +
+		` WHERE ` + q(repository.ColCreditCardOrderID) + ` = ` + qcol(repository.TableCreditCardOrders, repository.ColID) +
+		` ORDER BY ` + q(repository.ColTimestamp) + ` DESC) = ?`
+	query := repo.db.WithContext(ctx).Where(condition, repository.StatusOrderCreated)
 	return findAndMapAll(query, (*CreditCardOrder).toManufactureDataProto)
 }
 


### PR DESCRIPTION
TEMPORARY SOLUTION: Changed the working principle of GetOrdersToManufacture to check for orders with exactly one status record (the Created status). This is a workaround for the previous implementation which incorrectly retrieved orders regardless of their actual status.

Future refactoring: The Status, Details, and UpdatedAt fields should be moved directly to the CreditCardOrders table to eliminate the need for complex status table queries and simplify the data model. This method can then be removed entirely