### PR TITLE
fix(credit-card): use String account IDs instead of Integer throughout

### DIFF
--- a/src/credit-card-order-service/src/main/java/com/dynatrace/easytrade/creditcardorderservice/DbAdapterClient.java
+++ b/src/credit-card-order-service/src/main/java/com/dynatrace/easytrade/creditcardorderservice/DbAdapterClient.java
@@ -27,7 +27,7 @@ public class DbAdapterClient {
         this.stub = stub;
     }
 
-    public boolean hasExistingOrder(Integer accountId) {
+    public boolean hasExistingOrder(String accountId) {
         try {
             return stub.existsByAccountId(existsByAccountIdToProto(accountId)).getExists();
         } catch (StatusRuntimeException e) {
@@ -52,7 +52,7 @@ public class DbAdapterClient {
         }
     }
 
-    public Optional<CreditCardOrderStatusHistory> getStatusListByAccountId(Integer accountId) {
+    public Optional<CreditCardOrderStatusHistory> getStatusListByAccountId(String accountId) {
         try {
             List<CreditCardOrderStatusMessage> statuses = stub.getStatusListByAccountId(
                     statusListToProto(accountId)).getStatusesList();
@@ -67,10 +67,10 @@ public class DbAdapterClient {
         }
     }
 
-    public Optional<CreditCardOrderStatus> getLastOrderStatusByAccountId(Integer accountId) {
+    public Optional<CreditCardOrderStatus> getLastOrderStatusByAccountId(String accountId) {
         try {
             return Optional.of(fromProto(
-                    stub.getLastOrderStatusByAccountId(lastOrderStatusToProto(accountId))));
+                    stub.getLastOrderStatusByAccountId(lastOrderStatusByAccountIdToProto(accountId))));
         } catch (StatusRuntimeException e) {
             return handleNotFound(e, Optional.empty());
         }
@@ -79,7 +79,7 @@ public class DbAdapterClient {
     public Optional<CreditCardOrderStatus> getLastOrderStatusByOrderId(String orderId) {
         try {
             return Optional.of(fromProto(
-                    stub.getLastOrderStatusByOrderId(lastOrderStatusToProto(orderId))));
+                    stub.getLastOrderStatusByOrderId(lastOrderStatusByOrderIdToProto(orderId))));
         } catch (StatusRuntimeException e) {
             return handleNotFound(e, Optional.empty());
         }
@@ -125,7 +125,7 @@ public class DbAdapterClient {
         }
     }
 
-    public int deleteOrdersByAccountId(Integer accountId) {
+    public int deleteOrdersByAccountId(String accountId) {
         try {
             return stub.deleteOrdersByAccountId(deleteOrdersToProto(accountId)).getAffected();
         } catch (StatusRuntimeException e) {
@@ -135,7 +135,7 @@ public class DbAdapterClient {
 
     private CreateCreditCardOrderRequest toProto(CreditCardOrderRequest request) {
         return CreateCreditCardOrderRequest.newBuilder()
-                .setAccountId(request.accountId().toString())
+                .setAccountId(request.accountId())
                 .setEmail(request.email())
                 .setName(request.name())
                 .setShippingAddress(request.shippingAddress())
@@ -143,9 +143,9 @@ public class DbAdapterClient {
                 .build();
     }
 
-    private ExistsByAccountIdRequest existsByAccountIdToProto(Integer accountId) {
+    private ExistsByAccountIdRequest existsByAccountIdToProto(String accountId) {
         return ExistsByAccountIdRequest.newBuilder()
-                .setAccountId(accountId.toString())
+                .setAccountId(accountId)
                 .build();
     }
 
@@ -153,19 +153,19 @@ public class DbAdapterClient {
         return GetShippingAddressRequest.newBuilder().setOrderId(orderId).build();
     }
 
-    private GetStatusListByAccountIdRequest statusListToProto(Integer accountId) {
+    private GetStatusListByAccountIdRequest statusListToProto(String accountId) {
         return GetStatusListByAccountIdRequest.newBuilder()
-                .setAccountId(accountId.toString())
+                .setAccountId(accountId)
                 .build();
     }
 
-    private GetLastOrderStatusByAccountIdRequest lastOrderStatusToProto(Integer accountId) {
+    private GetLastOrderStatusByAccountIdRequest lastOrderStatusByAccountIdToProto(String accountId) {
         return GetLastOrderStatusByAccountIdRequest.newBuilder()
-                .setAccountId(accountId.toString())
+                .setAccountId(accountId)
                 .build();
     }
 
-    private GetLastOrderStatusByOrderIdRequest lastOrderStatusToProto(String orderId) {
+    private GetLastOrderStatusByOrderIdRequest lastOrderStatusByOrderIdToProto(String orderId) {
         return GetLastOrderStatusByOrderIdRequest.newBuilder()
                 .setOrderId(orderId)
                 .build();
@@ -203,9 +203,9 @@ public class DbAdapterClient {
                 .build();
     }
 
-    private DeleteOrdersRequest deleteOrdersToProto(Integer accountId) {
+    private DeleteOrdersRequest deleteOrdersToProto(String accountId) {
         return DeleteOrdersRequest.newBuilder()
-                .setAccountId(accountId.toString())
+                .setAccountId(accountId)
                 .build();
     }
 
@@ -218,7 +218,7 @@ public class DbAdapterClient {
                 Instant.ofEpochSecond(msg.getTimestamp().getSeconds(), msg.getTimestamp().getNanos()),
                 ZoneOffset.UTC);
         return new CreditCardOrderStatus(
-                Integer.parseInt(msg.getId()),
+                msg.getId(),
                 msg.getCreditCardOrderId(),
                 datetime,
                 msg.getStatus(),

--- a/src/credit-card-order-service/src/main/java/com/dynatrace/easytrade/creditcardorderservice/OrderController.java
+++ b/src/credit-card-order-service/src/main/java/com/dynatrace/easytrade/creditcardorderservice/OrderController.java
@@ -86,7 +86,7 @@ public class OrderController {
     }
 
     @GetMapping("/{accountId}/status")
-    public ResponseEntity<StandardResponse> getStatusHistory(@PathVariable Integer accountId) {
+    public ResponseEntity<StandardResponse> getStatusHistory(@PathVariable String accountId) {
         logger.info("Getting status history for accountId: " + accountId);
         try {
             Optional<CreditCardOrderStatusHistory> history = dbAdapterClient.getStatusListByAccountId(accountId);
@@ -100,7 +100,7 @@ public class OrderController {
     }
 
     @GetMapping("/{accountId}/status/latest")
-    public ResponseEntity<StandardResponse> getLatestStatus(@PathVariable Integer accountId) {
+    public ResponseEntity<StandardResponse> getLatestStatus(@PathVariable String accountId) {
         logger.info("Getting latest status for accountId: " + accountId);
         try {
             final Client client = openFeatureAPI.getClient();
@@ -122,7 +122,7 @@ public class OrderController {
     }
 
     @DeleteMapping("/{accountId}")
-    public ResponseEntity<StandardResponse> deleteOrder(@PathVariable Integer accountId) {
+    public ResponseEntity<StandardResponse> deleteOrder(@PathVariable String accountId) {
         logger.info("Deleting order and/or card for accountId: " + accountId);
         try {
             dbAdapterClient.deleteOrdersByAccountId(accountId);

--- a/src/credit-card-order-service/src/main/java/com/dynatrace/easytrade/creditcardorderservice/models/CreditCardOrderRequest.java
+++ b/src/credit-card-order-service/src/main/java/com/dynatrace/easytrade/creditcardorderservice/models/CreditCardOrderRequest.java
@@ -2,7 +2,7 @@ package com.dynatrace.easytrade.creditcardorderservice.models;
 
 import java.util.Objects;
 
-public record CreditCardOrderRequest(Integer accountId, String email, String name, String shippingAddress, String cardLevel) {
+public record CreditCardOrderRequest(String accountId, String email, String name, String shippingAddress, String cardLevel) {
     public CreditCardOrderRequest {
         Objects.requireNonNull(accountId);
         Objects.requireNonNull(email);

--- a/src/credit-card-order-service/src/main/java/com/dynatrace/easytrade/creditcardorderservice/models/CreditCardOrderStatus.java
+++ b/src/credit-card-order-service/src/main/java/com/dynatrace/easytrade/creditcardorderservice/models/CreditCardOrderStatus.java
@@ -2,6 +2,6 @@ package com.dynatrace.easytrade.creditcardorderservice.models;
 
 import java.time.OffsetDateTime;
 
-public record CreditCardOrderStatus(Integer id, String creditCardOrderId, OffsetDateTime timestamp, String status,
+public record CreditCardOrderStatus(String id, String creditCardOrderId, OffsetDateTime timestamp, String status,
                 String details) {
 }

--- a/src/credit-card-order-service/src/test/java/com/dynatrace/easytrade/creditcardorderservice/OrderControllerTests.java
+++ b/src/credit-card-order-service/src/test/java/com/dynatrace/easytrade/creditcardorderservice/OrderControllerTests.java
@@ -31,8 +31,8 @@ public class OrderControllerTests {
     @Test
     void grpcCallThrowsExceptionTest() {
         CreditCardOrderRequest request = new CreditCardOrderRequest(
-                13, "email@mail.ail", "Jane Doe", "Box 13", "silver");
-        Mockito.when(dbAdapterClient.hasExistingOrder(anyInt())).thenThrow(new RuntimeException("gRPC call failed"));
+                "a67a075f-f1b3-4fd4-bfbd-e4986cd11956", "email@mail.ail", "Jane Doe", "Box 13", "silver");
+        Mockito.when(dbAdapterClient.hasExistingOrder(anyString())).thenThrow(new RuntimeException("gRPC call failed"));
 
         OrderController controller = new OrderController(dbAdapterClient, openFeatureAPI);
         ResponseEntity<StandardResponse> response = controller.createCreditCardOrder(request);
@@ -44,9 +44,9 @@ public class OrderControllerTests {
     @Test
     void createAnotherOrderForSameAccountTest() {
         CreditCardOrderRequest request = new CreditCardOrderRequest(
-                13, "email@mail.ail", "Jane Doe", "Box 13", "silver");
+                "a67a075f-f1b3-4fd4-bfbd-e4986cd11956", "email@mail.ail", "Jane Doe", "Box 13", "silver");
 
-        Mockito.when(dbAdapterClient.hasExistingOrder(anyInt())).thenReturn(true);
+        Mockito.when(dbAdapterClient.hasExistingOrder(anyString())).thenReturn(true);
 
         checkOrderCreationResult(HttpStatus.BAD_REQUEST.value(), OrderController.ORDER_ALREADY_EXISTS, request);
     }
@@ -54,10 +54,10 @@ public class OrderControllerTests {
     @Test
     void createCreditCardOrderTest() {
         CreditCardOrderRequest request = new CreditCardOrderRequest(
-                13, "email@mail.ail", "Jane Doe", "Box 13", "silver");
+                "a67a075f-f1b3-4fd4-bfbd-e4986cd11956", "email@mail.ail", "Jane Doe", "Box 13", "silver");
         String guid = "b78a075f-e1b3-4fd4-afbd-f4986cd11945";
 
-        Mockito.when(dbAdapterClient.hasExistingOrder(anyInt())).thenReturn(false);
+        Mockito.when(dbAdapterClient.hasExistingOrder(anyString())).thenReturn(false);
         Mockito.when(dbAdapterClient.createOrder(request)).thenReturn(guid);
         Mockito.doNothing().when(dbAdapterClient).insertNewStatus(guid, StatusType.ORDER_CREATED);
 


### PR DESCRIPTION
OrderController, DbAdapterClient, CreditCardOrderRequest, and CreditCardOrderStatus all used Integer for account/status IDs. The underlying db-adapter stores these as UUIDs (string), and the frontend sends UUID account IDs, causing 400 Bad Request on every status and order endpoint.