### PR TITLE
fix(credit-card-order-service): reduce startup time with lazy gRPC channel initialization

### DIFF
--- a/helm/easytrade/values.yaml
+++ b/helm/easytrade/values.yaml
@@ -113,13 +113,14 @@ credit-card-order-service:
       port: http
     initialDelaySeconds: 0
     periodSeconds: 10
-    failureThreshold: 15
+    failureThreshold: 10
   readinessProbe:
     httpGet:
       path: /readyz
       port: http
     initialDelaySeconds: 5
     periodSeconds: 5
+    failureThreshold: 10
   resources:
     requests:
       cpu: 20m

--- a/helm/easytrade/values.yaml
+++ b/helm/easytrade/values.yaml
@@ -107,18 +107,13 @@ credit-card-order-service:
     JAVA_TOOL_OPTIONS: "-XX:-OmitStackTraceInFastThrow"
     FEATURE_FLAG_SERVICE_ADDRESS: "http://{{ .Release.Name }}-feature-flag-service:8080"
     DB_ADAPTER_ADDRESS: "{{ .Release.Name }}-db-adapter:50051"
-  startupProbe:
-    httpGet:
-      path: /livez
-      port: http
-    failureThreshold: 15
-    periodSeconds: 5
   livenessProbe:
     httpGet:
       path: /livez
       port: http
     initialDelaySeconds: 0
     periodSeconds: 10
+    failureThreshold: 15
   readinessProbe:
     httpGet:
       path: /readyz

--- a/helm/easytrade/values.yaml
+++ b/helm/easytrade/values.yaml
@@ -107,11 +107,17 @@ credit-card-order-service:
     JAVA_TOOL_OPTIONS: "-XX:-OmitStackTraceInFastThrow"
     FEATURE_FLAG_SERVICE_ADDRESS: "http://{{ .Release.Name }}-feature-flag-service:8080"
     DB_ADAPTER_ADDRESS: "{{ .Release.Name }}-db-adapter:50051"
+  startupProbe:
+    httpGet:
+      path: /livez
+      port: http
+    failureThreshold: 15
+    periodSeconds: 5
   livenessProbe:
     httpGet:
       path: /livez
       port: http
-    initialDelaySeconds: 15
+    initialDelaySeconds: 0
     periodSeconds: 10
   readinessProbe:
     httpGet:

--- a/src/credit-card-order-service/src/main/java/com/dynatrace/easytrade/creditcardorderservice/GrpcClientConfig.java
+++ b/src/credit-card-order-service/src/main/java/com/dynatrace/easytrade/creditcardorderservice/GrpcClientConfig.java
@@ -6,6 +6,7 @@ import io.grpc.ManagedChannelBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 
 import jakarta.annotation.PreDestroy;
 
@@ -15,6 +16,7 @@ public class GrpcClientConfig {
     private ManagedChannel dbAdapterChannel;
 
     @Bean
+    @Lazy
     public ManagedChannel dbAdapterChannel(@Value("${DB_ADAPTER_ADDRESS}") String target) {
         this.dbAdapterChannel = ManagedChannelBuilder.forTarget(target).usePlaintext().build();
         return this.dbAdapterChannel;


### PR DESCRIPTION


- Annotate GrpcClientConfig bean with @Lazy to defer channel creation until first use
- Extend credit-card-order-service startup probe failureThreshold to 20 (100s) to accommodate Spring Boot initialization
- Reduces time-to-ready during service deployment