### PR TITLE
chore: upgrade GitHub Actions to Node 24, ref: ASDY-27739

### DIFF
--- a/.github/workflows/reusable-promote-release.yaml
+++ b/.github/workflows/reusable-promote-release.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Download build artifacts
         if: ${{ inputs.artifact-name }}
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.artifact-name }}
           path: ${{ inputs.artifact-dir }}


### PR DESCRIPTION
## Summary

Upgrades outdated GitHub Actions to Node 24 compatible versions, fixing Node 20 deprecation warnings on GitHub-hosted runners.

- Bump `actions/download-artifact@v7` → `@v8`

refs: ASDY-27739

---
Assisted-by: Claude Code:claude-sonnet-4-6