### PR TITLE
"refactor(broker-service,db-adapter): simplify DbNotResponding pattern

### DIFF
--- a/src/broker-service/src/Entities/Trades/Repository/TradeMapper.cs
+++ b/src/broker-service/src/Entities/Trades/Repository/TradeMapper.cs
@@ -1,3 +1,4 @@
+using EasyTrade.BrokerService.Helpers;
 using EasyTrade.DbAdapter.Trade.Grpc;
 using Google.Protobuf.WellKnownTypes;
 
@@ -29,7 +30,7 @@ public static class TradeMapper
     {
         return new CreateTradeRequest
         {
-            AccountId = trade.AccountId.ToString(),
+            AccountId = ParseAccountId(trade),
             InstrumentId = trade.InstrumentId.ToString(),
             Direction = trade.Direction,
             Quantity = (double)trade.Quantity,
@@ -54,4 +55,9 @@ public static class TradeMapper
     }
 
     public static List<Trade> FromProto(IEnumerable<TradeMessage> protos) => [.. protos.Select(FromProto)];
+
+    private static string ParseAccountId(Trade trade)
+    {
+        return trade.AccountId == Guid.Empty ? Constants.InvalidAccountId : trade.AccountId.ToString();
+    }
 }

--- a/src/broker-service/src/Helpers/Constants.cs
+++ b/src/broker-service/src/Helpers/Constants.cs
@@ -10,7 +10,8 @@
         public const string HighCpuUsageConcurrency = "HIGH_CPU_USAGE_CONCURRENCY";
         public const string FeatureFlagCacheDurationS = "FEATURE_FLAG_CACHE_DURATION_S";
         public static readonly Guid OwnerId = Guid.Parse("a0000000-0000-4000-8000-000000000000");
-        public static readonly Guid InvalidTradeId = Guid.Empty;
+
+        public const string InvalidAccountId = "-1";
         public const string DbNotResponding = "db_not_responding";
         public const string HighCpuUsage = "high_cpu_usage";
         public const string CreditCardValidation = "credit_card_validation";

--- a/src/broker-service/src/Helpers/GrpcHelper.cs
+++ b/src/broker-service/src/Helpers/GrpcHelper.cs
@@ -9,13 +9,13 @@ public static class GrpcHelper
     public static async Task<T> ExecuteAsync<T>(Func<Task<T>> call, [CallerMemberName] string callerName = "")
     {
         try { return await call(); }
-        catch (Exception ex) { throw new DbException($"Db Adapter call error in \"{callerName}\" method", ex); }
+        catch (Exception ex) { throw new DbException($"Db Adapter call error in \"{callerName}\" method: {ex.Message}", ex); }
     }
 
     public static async Task<T?> ExecuteOrNullAsync<T>(Func<Task<T>> call, [CallerMemberName] string callerName = "") where T : class
     {
         try { return await call(); }
         catch (RpcException ex) when (ex.StatusCode == StatusCode.NotFound) { return null; }
-        catch (Exception ex) { throw new DbException($"Db Adapter call error in \"{callerName}\" method", ex); }
+        catch (Exception ex) { throw new DbException($"Db Adapter call error in \"{callerName}\" method: {ex.Message}", ex); }
     }
 }

--- a/src/broker-service/src/ProblemPatterns/DbNotResponding/TradeRepositoryWithDbNotResponding.cs
+++ b/src/broker-service/src/ProblemPatterns/DbNotResponding/TradeRepositoryWithDbNotResponding.cs
@@ -15,7 +15,7 @@ public class TradeRepositoryWithDbNotResponding(
     {
         if (await _pluginManager.GetPluginState(Constants.DbNotResponding, false))
         {
-            trade.Id = Constants.InvalidTradeId;
+            trade.AccountId = Guid.Empty;
         }
         return await base.CreateTradeAsync(trade);
     }

--- a/src/db-adapter/server/trade.go
+++ b/src/db-adapter/server/trade.go
@@ -20,9 +20,10 @@ func NewTradeServer(repo repository.TradeRepository) *TradeServer {
 }
 
 func (s *TradeServer) CreateTrade(ctx context.Context, req *pb.CreateTradeRequest) (*pb.TradeMessage, error) {
-	if err := validateUUID(req.AccountId); err != nil {
-		return nil, err
-	}
+	// AccountId validation commented skipped to allow DbNotResponding pattern to inject invalid value
+	// if err := validateUUID(req.AccountId); err != nil {
+	// 	return nil, err
+	// }
 	if err := validateUUID(req.InstrumentId); err != nil {
 		return nil, err
 	}

--- a/src/db-adapter/server/trade.go
+++ b/src/db-adapter/server/trade.go
@@ -20,10 +20,6 @@ func NewTradeServer(repo repository.TradeRepository) *TradeServer {
 }
 
 func (s *TradeServer) CreateTrade(ctx context.Context, req *pb.CreateTradeRequest) (*pb.TradeMessage, error) {
-	// AccountId validation commented skipped to allow DbNotResponding pattern to inject invalid value
-	// if err := validateUUID(req.AccountId); err != nil {
-	// 	return nil, err
-	// }
 	if err := validateUUID(req.InstrumentId); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
  - TradeRepositoryWithDbNotResponding now explicitly sets AccountId to Guid.Empty as marker
  - TradeMapper converts empty AccountId to invalid string '-1' for gRPC transmission
  - db-adapter skips AccountId validation to allow pattern to inject invalid values
  - Database rejects invalid UUID with genuine driver-level error
  - Removed createWithExplicitID helper and related constants
  - Simplified repository Create method to single insert path