### PR TITLE
feat: timer on feature flag

### DIFF
--- a/src/feature-flag-service/flag/model.go
+++ b/src/feature-flag-service/flag/model.go
@@ -3,15 +3,17 @@ package flag
 import (
 	"errors"
 	"fmt"
+	"time"
 )
 
 type Flag struct {
-	ID           string `json:"id"`
-	Enabled      bool   `json:"enabled"`
-	Name         string `json:"name"`
-	Description  string `json:"description"`
-	IsModifiable bool   `json:"isModifiable"`
-	Tag          string `json:"tag"`
+	ID           string     `json:"id"`
+	Enabled      bool       `json:"enabled"`
+	Name         string     `json:"name"`
+	Description  string     `json:"description"`
+	IsModifiable bool       `json:"isModifiable"`
+	Tag          string     `json:"tag"`
+	EnabledAt    *time.Time `json:"enabledAt,omitempty"`
 }
 
 type FlagContainer struct {

--- a/src/feature-flag-service/flag/service.go
+++ b/src/feature-flag-service/flag/service.go
@@ -1,6 +1,9 @@
 package flag
 
-import "sync"
+import (
+	"sync"
+	"time"
+)
 
 type Service struct {
 	mu    sync.RWMutex
@@ -49,6 +52,12 @@ func (s *Service) Update(id string, enabled bool) (*Flag, error) {
 	}
 	if !f.IsModifiable {
 		return nil, &NonModifiableError{Name: f.Name}
+	}
+	if enabled && !f.Enabled {
+		now := time.Now().UTC()
+		f.EnabledAt = &now
+	} else if !enabled {
+		f.EnabledAt = nil
 	}
 	f.Enabled = enabled
 	return f, nil

--- a/src/feature-flag-service/main.go
+++ b/src/feature-flag-service/main.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"time"
 
 	"dynatrace.com/easytrade/feature-flag-service/flag"
 )
@@ -22,7 +23,8 @@ func getEnvBool(key string, defaultVal bool) bool {
 
 func initFlags() map[string]*flag.Flag {
 	enableModify := getEnvBool("ENABLE_MODIFY", true)
-	return map[string]*flag.Flag{
+	startedAt := time.Now().UTC()
+	flags := map[string]*flag.Flag{
 		"frontend_feature_flag_management": {
 			ID:           "frontend_feature_flag_management",
 			Enabled:      getEnvBool("ENABLE_FRONTEND_MODIFY", true),
@@ -80,6 +82,13 @@ func initFlags() map[string]*flag.Flag {
 			Tag:          "problem_pattern",
 		},
 	}
+
+	for _, f := range flags {
+		if f.Enabled {
+			f.EnabledAt = &startedAt
+		}
+	}
+	return flags
 }
 
 func main() {

--- a/src/frontend/src/api/backend/problemPatterns.ts
+++ b/src/frontend/src/api/backend/problemPatterns.ts
@@ -5,6 +5,7 @@ export type FeatureFlag = {
     description: string
     isModifiable: boolean
     tag: string
+    enabledAt?: string
 }
 
 export type FlagResponseContainer = {

--- a/src/frontend/src/api/featureFlags/problemPatterns.ts
+++ b/src/frontend/src/api/featureFlags/problemPatterns.ts
@@ -8,8 +8,9 @@ function featureFlagMapper({
     name,
     description,
     isModifiable,
+    enabledAt,
 }: RawFeatureFlag): FeatureFlag {
-    return { id, enabled, name, description, isModifiable }
+    return { id, enabled, name, description, isModifiable, enabledAt }
 }
 
 export async function getFeatureFlags(): Promise<FeatureFlag[]> {

--- a/src/frontend/src/api/featureFlags/types.ts
+++ b/src/frontend/src/api/featureFlags/types.ts
@@ -4,6 +4,7 @@ export type FeatureFlag = {
     description: string
     enabled: boolean
     isModifiable: boolean
+    enabledAt?: string
 }
 
 export type HandlerResponse = {

--- a/src/frontend/src/components/featureFlags/FeatureFlagItem.tsx
+++ b/src/frontend/src/components/featureFlags/FeatureFlagItem.tsx
@@ -5,6 +5,7 @@ import { handleFlagToggle } from "../../api/featureFlags/problemPatterns"
 import { useConfigFlagsQuery } from "../../contexts/QueryContext/featureFlag/hooks"
 import { ContentCopyIcon, InfoIcon, LockIcon } from "../icons"
 import { useToast } from "../../contexts/ToastContext/context"
+import { useElapsed } from "./elapsed"
 
 function getFeatureFlagCurl(flagId: string, enable: boolean): string {
     return `curl -X PUT "${window.location.origin}/feature-flag-service/v1/flags/${flagId}" -H "Content-Type: application/json" -d '{"enabled": ${enable}}'`
@@ -16,13 +17,16 @@ export default function FeatureFlagItem({
     description,
     enabled,
     isModifiable,
+    enabledAt,
 }: {
     flagId: string
     name: string
     description?: string
     enabled: boolean
     isModifiable: boolean
+    enabledAt?: string
 }) {
+    const elapsed = useElapsed(enabled ? enabledAt : undefined)
     const [modalOpen, setModalOpen] = useState(false)
     const dialogRef = useRef<HTMLDialogElement>(null)
     const { showToast } = useToast()
@@ -73,7 +77,14 @@ export default function FeatureFlagItem({
         <>
             {/* List row */}
             <div className="flag-list-row">
-                <span className="flag-list-name">{displayName}</span>
+                <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-1)", minWidth: 0, flex: 1 }}>
+                    <span className="flag-list-name">{displayName}</span>
+                    {elapsed !== null && (
+                        <span style={{ color: "var(--text-secondary)", fontSize: "var(--text-xs)" }}>
+                            {`enabled ${elapsed} ago`}
+                        </span>
+                    )}
+                </div>
                 <div style={{ display: "flex", alignItems: "center", gap: "var(--space-3)", flexShrink: 0 }}>
                     {/* Toggle slider */}
                     <label

--- a/src/frontend/src/components/featureFlags/FeatureFlagList.tsx
+++ b/src/frontend/src/components/featureFlags/FeatureFlagList.tsx
@@ -5,7 +5,7 @@ import FeatureFlagItem from "./FeatureFlagItem"
 export default function FeatureFlagList({ featureFlags }: { featureFlags: FeatureFlag[] }) {
     return (
         <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
-            {featureFlags.map(({ id, name, description, enabled, isModifiable }, idx) => (
+            {featureFlags.map(({ id, name, description, enabled, isModifiable, enabledAt }, idx) => (
                 <FeatureFlagItem
                     key={idx}
                     flagId={id}
@@ -13,6 +13,7 @@ export default function FeatureFlagList({ featureFlags }: { featureFlags: Featur
                     description={description}
                     name={name}
                     isModifiable={isModifiable}
+                    enabledAt={enabledAt}
                 />
             ))}
         </div>

--- a/src/frontend/src/components/featureFlags/elapsed.ts
+++ b/src/frontend/src/components/featureFlags/elapsed.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react"
+
+const MS_IN_SECOND = 1000
+const MS_IN_MINUTE = 60 * MS_IN_SECOND
+const MS_IN_HOUR = 60 * MS_IN_MINUTE
+const MS_IN_DAY = 24 * MS_IN_HOUR
+
+function pad(n: number): string {
+    return n.toString().padStart(2, "0")
+}
+
+/**
+ * Formats a duration as a compact, human readable string.
+ * Seconds are only shown below one hour — that is the range where they
+ * matter while waiting for a problem pattern to show up in Dynatrace.
+ */
+export function formatElapsed(ms: number): string {
+    const total = Math.max(0, ms)
+
+    if (total < MS_IN_MINUTE) {
+        return `${Math.floor(total / MS_IN_SECOND)}s`
+    }
+    if (total < MS_IN_HOUR) {
+        const minutes = Math.floor(total / MS_IN_MINUTE)
+        const seconds = Math.floor((total % MS_IN_MINUTE) / MS_IN_SECOND)
+        return `${minutes}m ${pad(seconds)}s`
+    }
+    if (total < MS_IN_DAY) {
+        const hours = Math.floor(total / MS_IN_HOUR)
+        const minutes = Math.floor((total % MS_IN_HOUR) / MS_IN_MINUTE)
+        return `${hours}h ${pad(minutes)}m`
+    }
+    const days = Math.floor(total / MS_IN_DAY)
+    const hours = Math.floor((total % MS_IN_DAY) / MS_IN_HOUR)
+    return `${days}d ${hours}h`
+}
+
+/**
+ * Live counter of how long ago `enabledAt` was, re-rendering once a second.
+ * Returns null — and registers no interval — when there is no timestamp,
+ * so disabled flags cost nothing.
+ */
+export function useElapsed(enabledAt?: string): string | null {
+    const timestamp = enabledAt === undefined ? NaN : Date.parse(enabledAt)
+    const hasTimestamp = !Number.isNaN(timestamp)
+
+    const [now, setNow] = useState(() => Date.now())
+
+    useEffect(() => {
+        if (!hasTimestamp) return
+        setNow(Date.now())
+        const id = setInterval(() => setNow(Date.now()), MS_IN_SECOND)
+        return () => clearInterval(id)
+    }, [hasTimestamp, timestamp])
+
+    if (!hasTimestamp) return null
+    return formatElapsed(now - timestamp)
+}


### PR DESCRIPTION
## Summary
After running feature flags in EasyTrade, there is usually a delay before the results become visible in Dynatrace metrics. Since it can take some time, I added a small timer to help track when the measurement period starts

<img width="1912" height="895" alt="image (1)" src="https://github.com/user-attachments/assets/632909e2-3290-4adf-9c2d-63c5758085d0" />
